### PR TITLE
Add the delta store to the daemon's store map

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -807,6 +807,7 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 			imageStore: is,
 			layerStore: ls,
 		}
+		d.stores[runtime.GOOS] = *d.deltaStore
 		graphDrivers = append(graphDrivers, ls.DriverName())
 	}
 


### PR DESCRIPTION
The LayerDownloadManager uses this map to look up existing layers.

Connects-to: #24
Connects-to: #98
Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>